### PR TITLE
Fix IsVoiceOfBody incompatibility with rank-qualified Fellowship

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12175,6 +12175,7 @@ dependencies = [
  "sp-runtime 45.0.0",
  "sp-trie 42.0.1",
  "sp-weights",
+ "staging-xcm",
  "staging-xcm-builder",
 ]
 

--- a/relay/polkadot/constants/Cargo.toml
+++ b/relay/polkadot/constants/Cargo.toml
@@ -20,6 +20,7 @@ sp-weights = { workspace = true }
 sp-core = { workspace = true }
 sp-trie = { workspace = true, optional = true }
 
+xcm = { workspace = true }
 xcm-builder = { workspace = true }
 
 [features]
@@ -35,6 +36,7 @@ std = [
 	"sp-runtime/std",
 	"sp-trie?/std",
 	"sp-weights/std",
+	"xcm/std",
 	"xcm-builder/std",
 ]
 fast-runtime = []

--- a/relay/polkadot/constants/src/lib.rs
+++ b/relay/polkadot/constants/src/lib.rs
@@ -124,11 +124,49 @@ pub mod xcm {
 
 /// Fellowship-related constants.
 pub mod fellowship {
+	use core::marker::PhantomData;
+	use frame_support::traits::{Contains, Get};
+	use xcm::latest::prelude::*;
+
 	/// Fellowship Fellows rank (rank 3). The minimum rank with Fellowship privileges
 	/// in XCM location filters. Used with `GeneralIndex` in XCM locations.
 	pub const FELLOWS_RANK: u128 = 3;
 	/// Fellowship Architects rank (rank 4). Used with `GeneralIndex` in XCM locations.
 	pub const ARCHITECTS_RANK: u128 = 4;
+
+	/// Matches Fellowship voice locations in both legacy and new (rank-qualified) formats.
+	///
+	/// - Legacy: `[Prefix, Plurality { id: Technical, part: Voice }]`
+	/// - New: `[Prefix, Plurality { id: Technical, part: Voice }, GeneralIndex(rank)]` where `rank
+	///   >= FELLOWS_RANK`
+	///
+	/// Use this as a drop-in replacement for `IsVoiceOfBody<Prefix, FellowsBodyId>` in dispatch
+	/// origin checks to support the new rank-qualified Fellowship XCM locations.
+	pub struct IsFellowshipVoice<Prefix>(PhantomData<Prefix>);
+	impl<Prefix: Get<Location>> Contains<Location> for IsFellowshipVoice<Prefix> {
+		fn contains(l: &Location) -> bool {
+			let prefix = Prefix::get();
+			match l.match_and_split(&prefix) {
+				// Legacy format: last junction is Plurality{Technical, Voice}
+				Some(Plurality { id: BodyId::Technical, part: BodyPart::Voice }) => true,
+				// New format: extend prefix with Plurality and check for GeneralIndex(rank)
+				_ => {
+					let mut extended = prefix;
+					if extended
+						.append_with(Plurality { id: BodyId::Technical, part: BodyPart::Voice })
+						.is_ok()
+					{
+						matches!(
+							l.match_and_split(&extended),
+							Some(GeneralIndex(rank)) if *rank >= FELLOWS_RANK
+						)
+					} else {
+						false
+					}
+				},
+			}
+		}
+	}
 }
 
 /// System Parachains.

--- a/relay/polkadot/src/governance/mod.rs
+++ b/relay/polkadot/src/governance/mod.rs
@@ -17,9 +17,10 @@
 //! New governance configurations for the Polkadot runtime.
 
 use super::*;
-use crate::xcm_config::{CollectivesLocation, FellowsBodyId};
+use crate::xcm_config::CollectivesLocation;
 use frame_support::parameter_types;
 use frame_system::EnsureRootWithSuccess;
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 
 mod origins;
 pub use origins::{
@@ -65,7 +66,7 @@ impl pallet_whitelist::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WhitelistOrigin = EitherOfDiverse<
 		EnsureRoot<Self::AccountId>,
-		EnsureXcm<IsVoiceOfBody<CollectivesLocation, FellowsBodyId>>,
+		EnsureXcm<IsFellowshipVoice<CollectivesLocation>>,
 	>;
 	type DispatchWhitelistedOrigin = EitherOf<EnsureRoot<Self::AccountId>, WhitelistedCaller>;
 	type Preimages = Preimage;

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -87,6 +87,7 @@ use polkadot_runtime_common::{
 	traits::OnSwap,
 	BlockHashCount, BlockLength, CurrencyToVote, SlowAdjustingFeeUpdate,
 };
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 use sp_runtime::traits::Convert;
 
 use pallet_staking_async_ah_client as ah_client;
@@ -124,9 +125,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use xcm::prelude::*;
 use xcm_builder::PayOverXcm;
-use xcm_config::{
-	AssetHubLocation, CollectivesLocation, FellowsBodyId, GeneralAdminBodyId, StakingAdminBodyId,
-};
+use xcm_config::{AssetHubLocation, CollectivesLocation, GeneralAdminBodyId, StakingAdminBodyId};
 use xcm_runtime_apis::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},
 	fees::Error as XcmPaymentApiError,
@@ -1754,7 +1753,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	type AdminOrigin = EitherOfDiverse<
 		EnsureRoot<AccountId>,
 		EitherOfDiverse<
-			EnsureXcm<IsVoiceOfBody<CollectivesLocation, FellowsBodyId>>,
+			EnsureXcm<IsFellowshipVoice<CollectivesLocation>>,
 			EnsureXcm<Equals<AssetHubLocation>, Location>,
 		>,
 	>;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/governance/mod.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/governance/mod.rs
@@ -19,8 +19,8 @@
 use super::*;
 use crate::xcm_config::FellowshipLocation;
 use frame_system::EnsureRootWithSuccess;
-use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
-use xcm::latest::BodyId;
+use pallet_xcm::EnsureXcm;
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 
 mod origins;
 pub use origins::{
@@ -60,18 +60,13 @@ pub type TreasurySpender = EitherOf<EnsureRootWithSuccess<AccountId, MaxBalance>
 
 impl origins::pallet_custom_origins::Config for Runtime {}
 
-parameter_types! {
-	// Fellows pluralistic body.
-	pub const FellowsBodyId: BodyId = BodyId::Technical;
-}
-
 impl pallet_whitelist::Config for Runtime {
 	type WeightInfo = weights::pallet_whitelist::WeightInfo<Self>;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type WhitelistOrigin = EitherOfDiverse<
 		EnsureRoot<Self::AccountId>,
-		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
+		EnsureXcm<IsFellowshipVoice<FellowshipLocation>>,
 	>;
 	type DispatchWhitelistedOrigin = EitherOf<EnsureRoot<Self::AccountId>, WhitelistedCaller>;
 	type Preimages = Preimage;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -182,6 +182,7 @@ use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use polkadot_runtime_common::{
 	claims as pallet_claims, prod_or_fast, BlockHashCount, SlowAdjustingFeeUpdate,
 };
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, InMemoryDbWeight};
 
 impl_opaque_keys! {
@@ -887,10 +888,8 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	// need to set the page size larger than that until we reduce the channel size on-chain.
 	type MaxPageSize = ConstU32<{ 103 * 1024 }>;
 	type MaxInboundSuspended = sp_core::ConstU32<1_000>;
-	type ControllerOrigin = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
-	>;
+	type ControllerOrigin =
+		EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 	type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
 	type PriceForSiblingDelivery = PriceForSiblingParachainDelivery;
 }
@@ -1412,10 +1411,8 @@ impl pallet_ah_ops::Config for Runtime {
 	type AssetId = Location;
 	type RelevantAssets = RelevantAssets;
 	type RcBlockNumberProvider = RelaychainDataProvider<Runtime>;
-	type MigrateOrigin = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
-	>;
+	type MigrateOrigin =
+		EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 	type WeightInfo = weights::pallet_ah_ops::WeightInfo<Runtime>;
 	type MigrationCompletion = pallet_rc_migrator::types::MigrationCompletion<AhMigrator>;
 	type TreasuryPreMigrationAccount = xcm_config::PreMigrationRelayTreasuryPalletAccount;
@@ -1432,10 +1429,8 @@ impl pallet_ah_migrator::Config for Runtime {
 	type PortableHoldReason = pallet_rc_migrator::types::PortableHoldReason;
 	type PortableFreezeReason = pallet_rc_migrator::types::PortableFreezeReason;
 	type RuntimeEvent = RuntimeEvent;
-	type AdminOrigin = EitherOfDiverse<
-		EnsureRoot<AccountId>,
-		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
-	>;
+	type AdminOrigin =
+		EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 	type Currency = Balances;
 	type TreasuryBlockNumberProvider = RelaychainDataProvider<Runtime>;
 	type TreasuryPaymaster = treasury::TreasuryPaymaster;
@@ -2749,7 +2744,7 @@ impl pallet_state_trie_migration::Config for Runtime {
 	// An origin that can control the whole pallet: Should be a Fellowship member or the controller
 	// of the migration.
 	type ControlOrigin = EitherOfDiverse<
-		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
+		EnsureXcm<IsFellowshipVoice<FellowshipLocation>>,
 		EnsureSignedBy<MigControllerRoot, AccountId>,
 	>;
 	type SignedFilter = EnsureSignedBy<MigController, AccountId>;

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -73,6 +73,7 @@ use frame_system::{
 	EnsureRoot,
 };
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 use xcm_config::{
@@ -422,10 +423,8 @@ parameter_types! {
 }
 
 /// Privileged origin that represents Root or Fellows.
-pub type RootOrFellows = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
->;
+pub type RootOrFellows =
+	EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 
 pub type PriceForSiblingParachainDelivery = polkadot_runtime_common::xcm_sender::ExponentialPrice<
 	FeeAssetId,

--- a/system-parachains/coretime/coretime-polkadot/src/lib.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/lib.rs
@@ -58,6 +58,7 @@ use parachains_common::{
 	AccountId, AuraId, Balance, BlockNumber, Hash, Header, Nonce, Signature,
 };
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 #[cfg(any(feature = "std", test))]
@@ -377,10 +378,8 @@ impl parachain_info::Config for Runtime {}
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 /// Privileged origin that represents Root or Fellows pluralistic body.
-pub type RootOrFellows = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
->;
+pub type RootOrFellows =
+	EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 
 parameter_types! {
 	// Fellows pluralistic body.

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -56,6 +56,7 @@ use parachains_common::{
 	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
+use polkadot_runtime_constants::fellowship::IsFellowshipVoice;
 use sp_api::impl_runtime_apis;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -334,10 +335,8 @@ parameter_types! {
 }
 
 /// Privileged origin that represents Root or Fellows pluralistic body.
-pub type RootOrFellows = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
->;
+pub type RootOrFellows =
+	EitherOfDiverse<EnsureRoot<AccountId>, EnsureXcm<IsFellowshipVoice<FellowshipLocation>>>;
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
Fix IsVoiceOfBody incompatibility with rank-qualified Fellowship XCM locations

The new FellowsToLocation converter appends GeneralIndex(rank) to the
Fellowship XCM location, but IsVoiceOfBody does exact suffix matching on
the last junction. This means dispatch origin checks (whitelist, migration
control, etc.) silently fail because the last junction is now
GeneralIndex(3) instead of Plurality{Technical, Voice}.

Introduce IsFellowshipVoice<Prefix> in polkadot-runtime-constants that
matches both legacy and new rank-qualified formats, and replace all
IsVoiceOfBody<..., FellowsBodyId> usages across Polkadot chains.